### PR TITLE
image: Switch from PIL to Pillow

### DIFF
--- a/src/animate.py
+++ b/src/animate.py
@@ -50,7 +50,7 @@ a.delay(0.4)     	      set delay slider
 
 import sys, os, commands, re, glob
 from Tkinter import *
-from ImageTk import PhotoImage
+from PIL import ImageTk
 
 # Class definition
 

--- a/src/gl.py
+++ b/src/gl.py
@@ -127,7 +127,7 @@ g.sview(theta,phi,x,y,scale,up)      set all view parameters
 from math import sin,cos,sqrt,pi,acos
 from OpenGL.Tk import *
 from OpenGL.GLUT import *
-import Image
+from PIL import Image
 from vizinfo import vizinfo
 
 # Class definition

--- a/src/image.py
+++ b/src/image.py
@@ -53,7 +53,7 @@ import sys, os, commands, re, glob
 from math import *
 from Tkinter import *
 import Pmw
-import Image,ImageTk
+from PIL import Image,ImageTk
 
 try: from DEFAULTS import PIZZA_CONVERT
 except: PIZZA_CONVERT = "convert"


### PR DESCRIPTION
As can be [seen here](https://pypi.org/project/Pillow/2.1.0/) PIL does not seem to be easily obtainable nor in use. `Pillow` can be obtained by a simple `pip install`. 